### PR TITLE
fix sun angle issues

### DIFF
--- a/AssettoServer/Commands/Modules/GeneralModule.cs
+++ b/AssettoServer/Commands/Modules/GeneralModule.cs
@@ -21,7 +21,7 @@ namespace AssettoServer.Commands.Modules
 
         [Command("time")]
         public void Time()
-            => Reply($"It is currently {new DateTime().AddHours(Context.Server.CurrentDayTime):h:mm tt}.");
+            => Reply($"It is currently {new DateTime().AddSeconds(Context.Server.CurrentDayTime):H:mm}.");
 
 #if DEBUG
         [Command("test")]


### PR DESCRIPTION
- Replaced sun angle calculations with the ones from CM: https://github.com/gro-ove/actools/blob/master/AcTools/Processes/Game.Properties.cs#L465
- CurrentDayTime is now in seconds instead of hours
- There was a huge time skip when starting the server because lastTimeUpdate was initialized with 0 instead of Environment.TickCount64